### PR TITLE
Darker Dark Mode

### DIFF
--- a/src/controls/Theme.qml
+++ b/src/controls/Theme.qml
@@ -15,8 +15,8 @@ QtObject {
     property color pinkColor: MeuiKitCore.ThemeManager.pinkColor
     property color orangeColor: MeuiKitCore.ThemeManager.orangeColor
 
-    property color backgroundColor: darkMode ? "#3B3B3D" : "#FFFFFF"
-    property color secondBackgroundColor: darkMode ? "#2E2E2E" : "#F5F5F5"
+    property color backgroundColor: darkMode ? "#252525" : "#FFFFFF"
+    property color secondBackgroundColor: darkMode ? "#151515" : "#F5F5F5"
 
     property color textColor: darkMode ? "#FFFFFF" : "#171A20"
     property color disabledTextColor: darkMode ? "#888888" : "#5c5c5c"

--- a/src/meui-style/TabBar.qml
+++ b/src/meui-style/TabBar.qml
@@ -37,7 +37,7 @@ T.TabBar {
                     fill: parent
                     margins: 2
                 }
-                color: Meui.Theme.darkMode ? "#707074" : "#FFFFFF"
+                color: Meui.Theme.highlightColor
                 radius: Meui.Theme.smallRadius
 
                 layer.enabled: true
@@ -54,7 +54,7 @@ T.TabBar {
     }
 
     background: Rectangle {
-        color: Meui.Theme.darkMode ? Qt.lighter(Meui.Theme.backgroundColor, 1.3) : Meui.Theme.secondBackgroundColor
+        color: Meui.Theme.darkMode ? Qt.lighter(Meui.Theme.backgroundColor, 1.5) : Meui.Theme.secondBackgroundColor
         radius: Meui.Theme.smallRadius + 2
     }
 }

--- a/src/meui-style/TabBar.qml
+++ b/src/meui-style/TabBar.qml
@@ -37,7 +37,7 @@ T.TabBar {
                     fill: parent
                     margins: 2
                 }
-                color: Meui.Theme.highlightColor
+                color: Meui.Theme.darkMode ? Qt.lighter(Meui.Theme.backgroundColor, 2.2) : Meui.Theme.backgroundColor
                 radius: Meui.Theme.smallRadius
 
                 layer.enabled: true

--- a/src/meui-style/TabButton.qml
+++ b/src/meui-style/TabButton.qml
@@ -21,6 +21,6 @@ T.TabButton {
 
         text: control.text
         font: control.font
-        color: !control.enabled ? Meui.Theme.disabledTextColor : control.checked ? Meui.Theme.highlightedTextColor : Meui.Theme.textColor
+        color: !control.enabled ? Meui.Theme.disabledTextColor : control.checked ? Meui.Theme.textColor : Meui.Theme.textColor
     }
 }

--- a/src/meui-style/TabButton.qml
+++ b/src/meui-style/TabButton.qml
@@ -21,6 +21,6 @@ T.TabButton {
 
         text: control.text
         font: control.font
-        color: !control.enabled ? control.Meui.Theme.disabledTextColor : control.checked ? control.Meui.Theme.textColor : control.Meui.Theme.textColor
+        color: !control.enabled ? Meui.Theme.disabledTextColor : control.checked ? Meui.Theme.highlightedTextColor : Meui.Theme.textColor
     }
 }

--- a/src/meui-style/TextArea.qml
+++ b/src/meui-style/TextArea.qml
@@ -49,9 +49,9 @@ T.TextArea {
     verticalAlignment: TextEdit.AlignTop
     hoverEnabled: false
 
-    // Work around Qt bug where NativeRendering breaks for non-integer scale factors
     // https://bugreports.qt.io/browse/QTBUG-67007
-    renderType: Screen.devicePixelRatio % 1 !== 0 ? Text.QtRendering : Text.NativeRendering
+    // This bug has been fixed since 5.11.0 Beta 3.
+    renderType: Text.NativeRendering
 
     selectByMouse: true
 


### PR DESCRIPTION
I felt that the MeuiKit dark mode was a bit too... light.

This PR makes it darker. I'm unsure if you'll like it or not.

Some stuff will need adjustment though, such as:
 - Cyber Settings - the dark mode switch feels too light in dark mode, we should change it accordingly.
 - Cyber Terminal - it handles modes by switching QMLTermWidget color schemes, which cannot communicate directly with MeuiKit, we should update the color schemes (MeuiLight and MeuiDark) accordingly.
 - CyberOS Website - we need to change the dark mode CSS to fit MeuiKit.
 - Cyber KWin Plugins - they don't (or can't) inherit the colors from MeuiKit:  ![image](https://user-images.githubusercontent.com/17727163/108232490-21474b00-7143-11eb-9a94-c376c8ed54fd.png)

# Preview
![image](https://user-images.githubusercontent.com/17727163/108231924-8b132500-7142-11eb-9c62-f9a8c5e5417b.png)
(on a side note, I think that the Font part of the Appearance page would look better if it wasn't using the disabled color, to differentiate it from the header)
![image](https://user-images.githubusercontent.com/17727163/108231954-923a3300-7142-11eb-97b7-283679b163d6.png)
![image](https://user-images.githubusercontent.com/17727163/108231994-9cf4c800-7142-11eb-82b3-18262b55389f.png)
![image](https://user-images.githubusercontent.com/17727163/108232025-a54d0300-7142-11eb-8304-046fa260c15e.png)
